### PR TITLE
Bump golangci-lint version 1.58.1 -> 1.61.0

### DIFF
--- a/hack/make/dep_golangci_lint.mk
+++ b/hack/make/dep_golangci_lint.mk
@@ -5,7 +5,7 @@ $(call _assert_var,UNAME_ARCH)
 $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
-GOLANGCI_LINT_VERSION ?= 1.58.1
+GOLANGCI_LINT_VERSION ?= 1.61.0
 
 ARCH := $(UNAME_ARCH)
 ifeq ($(UNAME_ARCH),x86_64)


### PR DESCRIPTION
Update golangci-lint to 1.61.0 for compatibility with Go version 1.23.2.