### PR TITLE
Standardize project name to "preprocessing-demo"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,13 +1,12 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: 'Problem: '
-labels: ''
-assignees: ''
-
+title: "Problem: "
+labels: ""
+assignees: ""
 ---
 
-<!--- If this issue relates to a security vulnerability in Enduro or any of the related repositories, DO NOT file the issue here. Please see the security policy at https://github.com/archivematica/Issues/security/policy for information on how to safely report a security vulnerability. --->
+<!--- If this issue relates to a security vulnerability in preprocessing-demo or any of the related repositories, DO NOT file the issue here. Please see the security policy at https://github.com/archivematica/Issues/security/policy for information on how to safely report a security vulnerability. --->
 
 <!--- Please title your issue as a problem statement, starting with "Problem:". Check existing issues for examples. --->
 
@@ -18,6 +17,7 @@ A clear and concise description of what the bug is.
 **To Reproduce**
 
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters-settings:
     sections:
       - standard
       - default
-      - prefix(github.com/artefactual-sdps/preprocessing-base)
+      - prefix(github.com/artefactual-sdps/preprocessing-demo)
     section-separators:
       - newLine
   gofumpt:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT := preprocessing-base
+PROJECT := preprocessing-demo
 MAKEDIR := hack/make
 SHELL   := /bin/bash
 
@@ -39,8 +39,8 @@ define NEWLINE
 endef
 
 IGNORED_PACKAGES := \
-	github.com/artefactual-sdps/preprocessing-base/hack/% \
-	github.com/artefactual-sdps/preprocessing-sfa/internal/enums
+	github.com/artefactual-sdps/$(PROJECT)/hack/% \
+	github.com/artefactual-sdps/$(PROJECT)/internal/enums
 PACKAGES := $(shell go list ./...)
 TEST_PACKAGES := $(filter-out $(IGNORED_PACKAGES),$(PACKAGES))
 TEST_IGNORED_PACKAGES := $(filter $(IGNORED_PACKAGES),$(PACKAGES))

--- a/Tiltfile
+++ b/Tiltfile
@@ -16,7 +16,7 @@ if os.environ.get('TRIGGER_MODE_AUTO', '').lower() in true:
 
 # Docker images
 custom_build(
-  ref="preprocessing-base-worker:dev",
+  ref="preprocessing-demo-worker:dev",
   command=["hack/build_docker.sh"],
   deps=["."],
 )

--- a/Tiltfile.enduro
+++ b/Tiltfile.enduro
@@ -16,7 +16,7 @@ if os.environ.get("TRIGGER_MODE_AUTO", "").lower() in true:
 
 # Docker images
 custom_build(
-  ref="preprocessing-base-worker:dev",
+  ref="preprocessing-demo-worker:dev",
   command=["hack/build_docker.sh"],
   deps=["."],
 )

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -11,12 +11,12 @@ import (
 	"github.com/spf13/pflag"
 	"go.artefactual.dev/tools/log"
 
-	"github.com/artefactual-sdps/preprocessing-base/cmd/worker/workercmd"
-	"github.com/artefactual-sdps/preprocessing-base/internal/config"
-	"github.com/artefactual-sdps/preprocessing-base/internal/version"
+	"github.com/artefactual-sdps/preprocessing-demo/cmd/worker/workercmd"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/config"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/version"
 )
 
-const appName = "preprocessing-base-worker"
+const appName = "preprocessing-demo-worker"
 
 func main() {
 	p := pflag.NewFlagSet(workercmd.Name, pflag.ExitOnError)

--- a/cmd/worker/workercmd/cmd.go
+++ b/cmd/worker/workercmd/cmd.go
@@ -12,8 +12,8 @@ import (
 	temporalsdk_worker "go.temporal.io/sdk/worker"
 	temporalsdk_workflow "go.temporal.io/sdk/workflow"
 
-	"github.com/artefactual-sdps/preprocessing-base/internal/config"
-	"github.com/artefactual-sdps/preprocessing-base/internal/workflow"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/config"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/workflow"
 )
 
 const Name = "preprocessing-worker"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/artefactual-sdps/preprocessing-base
+module github.com/artefactual-sdps/preprocessing-demo
 
 go 1.23.2
 

--- a/hack/build_dist.sh
+++ b/hack/build_dist.sh
@@ -7,7 +7,7 @@
 
 set -eu
 
-MODULE_PATH="${MODULE_PATH:-github.com/artefactual-sdps/preprocessing-base}"
+MODULE_PATH="${MODULE_PATH:-github.com/artefactual-sdps/preprocessing-demo}"
 
 IFS=".$IFS" read -r major minor patch < internal/version/VERSION.txt
 version_path=${MODULE_PATH}/internal/version

--- a/hack/build_docker.sh
+++ b/hack/build_docker.sh
@@ -4,7 +4,7 @@ set -eu
 
 eval $(./hack/build_dist.sh shellvars)
 
-DEFAULT_IMAGE_NAME="preprocessing-base-worker:${VERSION_SHORT}"
+DEFAULT_IMAGE_NAME="preprocessing-demo-worker:${VERSION_SHORT}"
 TILT_EXPECTED_REF=${EXPECTED_REF:-}
 IMAGE_NAME="${TILT_EXPECTED_REF:-$DEFAULT_IMAGE_NAME}"
 BUILD_OPTS="${BUILD_OPTS:-}"

--- a/hack/kube/base/preprocessing-worker.yaml
+++ b/hack/kube/base/preprocessing-worker.yaml
@@ -19,7 +19,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: preprocessing-worker
-          image: preprocessing-base-worker:dev
+          image: preprocessing-demo-worker:dev
           volumeMounts:
             - name: config
               mountPath: /home/preprocessing/.config

--- a/hack/kube/overlays/enduro/preprocessing-worker.yaml
+++ b/hack/kube/overlays/enduro/preprocessing-worker.yaml
@@ -19,7 +19,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: preprocessing-worker
-          image: preprocessing-base-worker:dev
+          image: preprocessing-demo-worker:dev
           volumeMounts:
             - name: config
               mountPath: /home/preprocessing/.config

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,7 +7,7 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/fs"
 
-	"github.com/artefactual-sdps/preprocessing-base/internal/config"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/config"
 )
 
 const testConfig = `# Config

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/artefactual-sdps/preprocessing-base/internal/enums"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/enums"
 )
 
 type Event struct {

--- a/internal/eventlog/eventlog_test.go
+++ b/internal/eventlog/eventlog_test.go
@@ -7,8 +7,8 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	"github.com/artefactual-sdps/preprocessing-base/internal/enums"
-	"github.com/artefactual-sdps/preprocessing-base/internal/eventlog"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/enums"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/eventlog"
 )
 
 func TestEvent(t *testing.T) {

--- a/internal/workflow/preprocessing.go
+++ b/internal/workflow/preprocessing.go
@@ -10,8 +10,8 @@ import (
 	temporalsdk_temporal "go.temporal.io/sdk/temporal"
 	temporalsdk_workflow "go.temporal.io/sdk/workflow"
 
-	"github.com/artefactual-sdps/preprocessing-base/internal/enums"
-	"github.com/artefactual-sdps/preprocessing-base/internal/eventlog"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/enums"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/eventlog"
 )
 
 type Outcome int

--- a/internal/workflow/preprocessing_test.go
+++ b/internal/workflow/preprocessing_test.go
@@ -12,10 +12,10 @@ import (
 	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
 	temporalsdk_worker "go.temporal.io/sdk/worker"
 
-	"github.com/artefactual-sdps/preprocessing-base/internal/config"
-	"github.com/artefactual-sdps/preprocessing-base/internal/enums"
-	"github.com/artefactual-sdps/preprocessing-base/internal/eventlog"
-	"github.com/artefactual-sdps/preprocessing-base/internal/workflow"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/config"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/enums"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/eventlog"
+	"github.com/artefactual-sdps/preprocessing-demo/internal/workflow"
 )
 
 const sharedPath = "/shared/path/"


### PR DESCRIPTION
Search and replace instances of "preprocessing-base" and "enduro-sdps" in project URLs and names.